### PR TITLE
Scrubber mine

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
@@ -45,6 +45,7 @@ public enum ItemUseType {
     PROTECTED,
     PUBLIC,
     RECYCLER(new RecyclerInteraction()),
+    SCRUBBER,
     SPAWN(new SpawnInteraction()),
     SPAWN_TELEPORT(new SpawnTeleportInteraction()),
     SWITCH(new SwitchInteraction()),

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
@@ -39,7 +39,8 @@ public class BlockMineRequest extends PlayerRequest {
     public void process(Player player) {
         Zone zone = player.getZone();
         boolean digging = item.isDiggable() && player.getHeldItem().getAction() == Action.DIG;
-        
+        boolean scrubbing = player.getHeldItem().hasUse(ItemUseType.SCRUBBER);
+
         if(player.isDead()) {
             return;
         }
@@ -90,6 +91,14 @@ public class BlockMineRequest extends PlayerRequest {
         if(digging) {
             zone.digBlock(x, y);
             return;
+        }
+
+        if (scrubbing) {
+            zone.updateBlock(x, y, Layer.BASE, Item.get(1));
+            // // Add if you don't want the top block to be destroyed.
+            // Block myBlock = player.getZone().getBlock(x, y);
+            // player.sendDelayedMessage(new BlockChangeMessage(x, y, layer, myBlock.getItem(layer), myBlock.getMod(layer)));
+            // return;
         }
         
         // Apply decay if block is being mined with a hatchet


### PR DESCRIPTION
`tools/scrubber` has a mining action which will be overridden in BlockMineRequest so it mines the block like a pickaxe along with the backdrop. It can't mine a backdrop without any blocks in front due to client side limitations.

config-overrides.yml
```yaml
inventory:
  - name: tools
    items:
    - tools/scrubber
```

config-items.yml
```yaml
items:
  tools/scrubber:
    <<: *melee
    code: 2098
    action: mine
    glow: 0.7
    damage: ['energy', 0.375]
    critical_hit: 0.025
    use:
      scrubber: true
    #ingredients: [['building/brass', 2], ['building/iron', 2], ['ground/quartz-ore', 5], 'ground/crystal-red-1', 'accessories/schematic']
    #crafting skill: ['engineering', 5]
```