### PR TITLE
implement to render (*player*) as functional for switch and touchplate

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/entity/EntityConfig.java
+++ b/gameserver/src/main/java/brainwine/gameserver/entity/EntityConfig.java
@@ -26,6 +26,7 @@ public class EntityConfig {
     
     private final String name;
     private final int type;
+    private String title = "Unknown";
     private int experienceYield;
     private float maxHealth = Entity.DEFAULT_HEALTH;
     private float baseSpeed = 3;
@@ -68,7 +69,11 @@ public class EntityConfig {
     public int getType() {
         return type;
     }
-    
+
+    public String getTitle() {
+        return title;
+    }
+
     @JsonProperty("xp")
     public int getExperienceYield() {
         return experienceYield;

--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/SwitchInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/SwitchInteraction.java
@@ -40,7 +40,7 @@ public class SwitchInteraction implements ItemInteraction {
         }
         
         // Show configured message to nearby players
-        String message = metaBlock.getStringProperty("m");
+        String message = interpolateMessage(entity, metaBlock.getStringProperty("m"));
         
         if(message != null && !message.isEmpty()) {
             float effectX = x + item.getBlockWidth() / 2.0F;
@@ -223,10 +223,17 @@ public class SwitchInteraction implements ItemInteraction {
             if(entity.isPlayer()) {
                 entityName = entity.getName() == null ? "Anon" : entity.getName();
             } else {
-                entityName = "entity";
+                Npc npc = (Npc) entity;
+                if(npc.getName() == null) {
+                    entityName = npc.getConfig() != null
+                            ? npc.getConfig().getTitle()
+                            : "Unknown";
+                } else {
+                    entityName = npc.getName();
+                }
             }
 
-            current = current.replaceAll("\\*(player|mob)\\*", entityName);
+            current = current.replaceAll("\\*(player|mob)\\*", entityName == null ? "null" : entityName);
         }
 
         return current;

--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/SwitchInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/SwitchInteraction.java
@@ -165,7 +165,7 @@ public class SwitchInteraction implements ItemInteraction {
     }
     
     private void switchSign(Zone zone, Entity entity, MetaBlock metaBlock, MetaBlock switchMeta) {
-        String message = switchMeta.hasProperty("m") ? switchMeta.getStringProperty("m").trim() : "";
+        String message = interpolateMessage(entity, switchMeta.hasProperty("m") ? switchMeta.getStringProperty("m").trim() : "");
         boolean lock = metaBlock.hasProperty("lock") && metaBlock.getStringProperty("lock").equalsIgnoreCase("yes");
         Item item = metaBlock.getItem();
         
@@ -212,5 +212,23 @@ public class SwitchInteraction implements ItemInteraction {
         float effectY = metaBlock.getY() - (float)item.getBlockHeight() / 2 + 1;
         zone.spawnEffect(effectX, effectY, "area steam", 10);
         zone.sendBlockMetaUpdate(metaBlock);
+    }
+
+    private String interpolateMessage(Entity entity, String message) {
+        String current = message;
+
+        if(entity != null) {
+            String entityName;
+
+            if(entity.isPlayer()) {
+                entityName = entity.getName() == null ? "Anon" : entity.getName();
+            } else {
+                entityName = "entity";
+            }
+
+            current = current.replaceAll("\\*(player|mob)\\*", entityName);
+        }
+
+        return current;
     }
 }


### PR DESCRIPTION
When implemented the input '*player*' for a switch or a touchplate will output player's username or any entity that triggers it. Also works when combined with mechanical sign.