### PR TITLE
Add ip banning

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/GameServer.java
+++ b/gameserver/src/main/java/brainwine/gameserver/GameServer.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import brainwine.gameserver.order.OrderManager;
 import brainwine.gameserver.server.DefaultPusher;
+import brainwine.gameserver.server.IpBans;
 import brainwine.gameserver.server.Pusher;
 import brainwine.gameserver.zone.ZoneActivityManager;
 import brainwine.gameserver.achievement.AchievementManager;
@@ -42,6 +43,7 @@ public class GameServer implements CommandExecutor {
     private final ZoneManager zoneManager;
     private final ZoneActivityManager zoneActivityManager;
     private final PlayerManager playerManager;
+    private final IpBans ipBans;
     private final Server server;
     private Pusher pusher;
     private long lastTick = System.currentTimeMillis();
@@ -53,6 +55,7 @@ public class GameServer implements CommandExecutor {
         handlerThread = Thread.currentThread();
         long startTime = System.currentTimeMillis();
         logger.info(SERVER_MARKER, "Starting GameServer ...");
+        ipBans = new IpBans();
         CommandManager.init();
         GameConfiguration.init();
         AchievementManager.loadAchievements();
@@ -64,6 +67,7 @@ public class GameServer implements CommandExecutor {
         Quests.loadQuests();
         Fake.loadFake();
         AnticheatManager.loadConfig();
+        ipBans.loadIpBans();
         lootManager = new LootManager();
         prefabManager = new PrefabManager();
         ZoneGenerator.init();
@@ -101,6 +105,7 @@ public class GameServer implements CommandExecutor {
         if(lastSave + GLOBAL_SAVE_INTERVAL < System.currentTimeMillis()) {
             zoneManager.saveZones();
             playerManager.savePlayers();
+            ipBans.saveIpBans();
             lastSave = System.currentTimeMillis();
         }
         
@@ -143,6 +148,7 @@ public class GameServer implements CommandExecutor {
         zoneManager.onShutdown();
         logger.info(SERVER_MARKER, "Saving player data ...");
         playerManager.savePlayers();
+        ipBans.saveIpBans();
     }
     
     public void stopGracefully() {
@@ -179,5 +185,9 @@ public class GameServer implements CommandExecutor {
 
     public void setPusher(Pusher pusher) {
         this.pusher = pusher;
+    }
+
+    public IpBans getIpBans() {
+        return ipBans;
     }
 }

--- a/gameserver/src/main/java/brainwine/gameserver/command/admin/BanCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/admin/BanCommand.java
@@ -18,7 +18,7 @@ public class BanCommand extends Command {
 
     @Override
     public void execute(CommandExecutor executor, String[] args) {
-        if(args.length < 2) {
+        if(args.length < 3) {
             executor.notify(String.format("Usage: %s", getUsage(executor)), SYSTEM);
             return;
         }
@@ -47,22 +47,36 @@ public class BanCommand extends Command {
             executor.notify("Time units: y = years, w = weeks, d = days, h = hours, m = minutes", SYSTEM);
             return;
         }
+
+        boolean ipBan;
+        if("true".equalsIgnoreCase(args[2])) {
+            ipBan = true;
+        } else if("false".equalsIgnoreCase(args[2])){
+            ipBan = false;
+        } else {
+            executor.notify("IP ban argument must be true or false.", SYSTEM);
+            return;
+        }
         
         String reason = "The ban hammer has spoken!";
         
-        if(args.length > 2) {
-            reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
+        if(args.length > 3) {
+            reason = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
         }
         
         OffsetDateTime endDate = OffsetDateTime.now().plusMinutes(duration);
         target.ban(executor instanceof Player ? (Player)executor : null, reason, endDate);
+        if(ipBan) {
+            GameServer.getInstance().getIpBans().ban(target);
+        }
+
         executor.notify(String.format("Banned %s until %s for '%s'", 
                 target.getName(), endDate.format(DateTimeFormatter.RFC_1123_DATE_TIME), reason), SYSTEM);
     }
     
     @Override
     public String getUsage(CommandExecutor executor) {
-        return "/ban <player> <duration> [reason]";
+        return "/ban <player> <duration> <ban ip> [reason]";
     }
     
     @Override

--- a/gameserver/src/main/java/brainwine/gameserver/command/admin/BanIpCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/admin/BanIpCommand.java
@@ -1,0 +1,75 @@
+package brainwine.gameserver.command.admin;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.Command;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.player.NotificationType;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+import brainwine.gameserver.util.Cidr;
+import brainwine.gameserver.util.DateTimeUtils;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+import static brainwine.gameserver.player.NotificationType.SYSTEM;
+
+@CommandInfo(name = "banip", description = "Bans a player from the server.")
+public class BanIpCommand extends Command {
+
+    @Override
+    public void execute(CommandExecutor executor, String[] args) {
+        if(args.length < 1) {
+            executor.notify(String.format("Usage: %s", getUsage(executor)), SYSTEM);
+            return;
+        }
+
+        Cidr target;
+        try {
+            target = Cidr.create(args[0]);
+        } catch(IllegalArgumentException e) {
+            executor.notify("Provided IP address is not in a valid format. " + e.getMessage(), SYSTEM);
+            return;
+        }
+
+        Player scapegoat = null;
+        if(args.length >= 2) {
+            scapegoat = GameServer.getInstance().getPlayerManager().getPlayer(args[1]);
+            if(scapegoat == null) {
+                executor.notify("Scapegoat " + args[1] + " does not exist.", SYSTEM);
+                return;
+            }
+        }
+
+        if(executor instanceof Player && target.matches(((Player)executor).getConnection().getIpAddress())) {
+            executor.notify("You would be banning your own IP this way.", SYSTEM);
+            return;
+        }
+
+        GameServer.getInstance().getIpBans().banCidr(target, scapegoat);
+
+        if(scapegoat == null) {
+            executor.notify(String.format("Connections from %s will be blocked.", target), SYSTEM);
+        } else {
+            executor.notify(String.format("Players connecting from %s will be banned for the same reason as %s.", target, scapegoat.getName()), SYSTEM);
+        }
+
+        for(Player player : GameServer.getInstance().getPlayerManager().getOnlinePlayers()) {
+            if(target.matches(player.getConnection().getIpAddress())) {
+                player.kick("Your IP address has been blocked.");
+            }
+        }
+    }
+    
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/banip <ip or CIDR> [scapegoat player]";
+    }
+    
+    @Override
+    public boolean canExecute(CommandExecutor executor) {
+        return executor.isAdmin();
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanCommand.java
@@ -6,7 +6,10 @@ import brainwine.gameserver.GameServer;
 import brainwine.gameserver.command.Command;
 import brainwine.gameserver.command.CommandExecutor;
 import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.player.NotificationType;
 import brainwine.gameserver.player.Player;
+
+import java.util.Set;
 
 @CommandInfo(name = "unban", description = "Unbans a player.", aliases = "pardon")
 public class UnbanCommand extends Command {
@@ -31,6 +34,16 @@ public class UnbanCommand extends Command {
         }
         
         target.unban(executor instanceof Player ? (Player)executor : null);
+
+        Set<String> banBlocks = GameServer.getInstance().getIpBans().unbanAndCheckForCidrBlock(target);
+        if(!banBlocks.isEmpty()) {
+            executor.notify(
+                    "Warning: This user might still be indirectly banned due to a IP address block ban. You can unban the following IP addresses to fix this: "
+                            + String.join(", ", banBlocks),
+                    NotificationType.SYSTEM
+            );
+        }
+
         executor.notify(String.format("Player %s has been unbanned.", target.getName()), SYSTEM);
     }
     

--- a/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanIpCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanIpCommand.java
@@ -4,7 +4,6 @@ import brainwine.gameserver.GameServer;
 import brainwine.gameserver.command.Command;
 import brainwine.gameserver.command.CommandExecutor;
 import brainwine.gameserver.command.CommandInfo;
-import brainwine.gameserver.player.Player;
 import brainwine.gameserver.server.IpBans;
 import brainwine.gameserver.util.Cidr;
 
@@ -29,7 +28,7 @@ public class UnbanIpCommand extends Command {
         }
 
         if(!GameServer.getInstance().getIpBans().isCidrBanned(target)) {
-            IpBans.Item item = GameServer.getInstance().getIpBans().getIpBanItem(target);
+            IpBans.Item item = GameServer.getInstance().getIpBans().findMatchingIpBan(target);
             if(item == null) {
                 executor.notify("This specific CIDR was not banned. No changes have been made.", SYSTEM);
             } else {

--- a/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanIpCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/admin/UnbanIpCommand.java
@@ -1,0 +1,55 @@
+package brainwine.gameserver.command.admin;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.Command;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.server.IpBans;
+import brainwine.gameserver.util.Cidr;
+
+import static brainwine.gameserver.player.NotificationType.SYSTEM;
+
+@CommandInfo(name = "unbanip", description = "Bans a player from the server.")
+public class UnbanIpCommand extends Command {
+
+    @Override
+    public void execute(CommandExecutor executor, String[] args) {
+        if(args.length < 1) {
+            executor.notify(String.format("Usage: %s", getUsage(executor)), SYSTEM);
+            return;
+        }
+
+        Cidr target;
+        try {
+            target = Cidr.create(args[0]);
+        } catch(IllegalArgumentException e) {
+            executor.notify("Provided IP address is not in a valid format. " + e.getMessage(), SYSTEM);
+            return;
+        }
+
+        if(!GameServer.getInstance().getIpBans().isCidrBanned(target)) {
+            IpBans.Item item = GameServer.getInstance().getIpBans().getIpBanItem(target);
+            if(item == null) {
+                executor.notify("This specific CIDR was not banned. No changes have been made.", SYSTEM);
+            } else {
+                executor.notify("This specific CIDR was not banned, however " + item.getIpAddress() + " is. No changes have been made.", SYSTEM);
+            }
+            return;
+        }
+
+        GameServer.getInstance().getIpBans().unbanCidr(target);
+
+        executor.notify(String.format("Players connecting from %s will no longer be kicked or banned.", target), SYSTEM);
+    }
+    
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/unbanip <ip or CIDR>";
+    }
+    
+    @Override
+    public boolean canExecute(CommandExecutor executor) {
+        return executor.isAdmin();
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/player/PlayerManager.java
+++ b/gameserver/src/main/java/brainwine/gameserver/player/PlayerManager.java
@@ -185,7 +185,7 @@ public class PlayerManager {
     
     public void onPlayerConnect(Player player) {
         onlinePlayers.add(player);
-        logger.info(SERVER_MARKER, "{} logged into zone {}", player.getName(), player.getZone().getName());
+        logger.info(SERVER_MARKER, "{} logged into zone {} with IP address {}", player.getName(), player.getZone().getName(), player.getConnection().getIpAddress());
     }
     
     public void onPlayerDisconnect(Player player) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
@@ -1,0 +1,157 @@
+package brainwine.gameserver.server;
+
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.server.pipeline.Connection;
+import brainwine.gameserver.util.Cidr;
+import brainwine.shared.JsonHelper;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class IpBans {
+    private static final Logger logger = LogManager.getLogger();
+    private final String FILE_NAME = "banned-ips.json";
+
+    List<Item> bannedIps = new ArrayList<>();
+    Map<Cidr, Item> bansByIp = new HashMap<>();
+
+    public void loadIpBans() {
+        logger.info("Loading ip bans ...");
+        try {
+            bannedIps = JsonHelper.readValue(new File(FILE_NAME), new TypeReference<List<Item>>() {});
+            for(Item item : bannedIps) {
+                bansByIp.put(item.getIpAddress(), item);
+            }
+        } catch(IOException e) {
+            logger.error("Failed to read " + FILE_NAME, e);
+        }
+    }
+
+    public void saveIpBans() {
+        try {
+            JsonHelper.writeValue(new File(FILE_NAME), bannedIps);
+        } catch(IOException e) {
+            logger.error("Failed to write " + FILE_NAME, e);
+        }
+    }
+
+    public Item getIpBanItem(Cidr playerIp) {
+        for(Item bannedItem : bannedIps) {
+            if(playerIp.matches(bannedItem.getIpAddress())) {
+                return bannedItem;
+            }
+        }
+        return null;
+    }
+
+    public boolean isCidrBanned(Cidr bannedIp) {
+        return bansByIp.containsKey(bannedIp);
+    }
+
+    public void banCidr(Cidr bannedIp, Player scapegoat) {
+        Item item = bansByIp.get(bannedIp);
+        if(item == null) {
+            item = new Item(bannedIp);
+            bannedIps.add(item);
+            bansByIp.put(bannedIp, item);
+        }
+        if(scapegoat != null) {
+            item.getKnownUuids().add(scapegoat.getDocumentId());
+            item.getKnownUsernames().add(scapegoat.getName());
+        }
+    }
+
+    public void unbanCidr(Cidr bannedIp) {
+        Item item = bansByIp.remove(bannedIp);
+        bannedIps.remove(item);
+    }
+
+    public void ban(Player player) {
+        if(!player.isOnline()) return;
+
+        Cidr playerIp = player.getConnection().getIpAddress();
+        Item banByIpAddress = bansByIp.get(playerIp);
+
+        if(banByIpAddress == null) {
+            banByIpAddress = new Item(playerIp);
+            bannedIps.add(banByIpAddress);
+            bansByIp.put(playerIp, banByIpAddress);
+        }
+
+        banByIpAddress.getKnownUuids().add(player.getDocumentId());
+        banByIpAddress.getKnownUsernames().add(player.getName());
+    }
+
+    public Set<String> unbanAndCheckForCidrBlock(Player player) {
+        return player.isOnline() ? unbanAndCheckForCidrBlock(player, player.getConnection()) : new HashSet<>();
+    }
+
+    public Set<String> unbanAndCheckForCidrBlock(Player player, Connection connection) {
+        Set<String> ipBlocks = new HashSet<>();
+        List<Item> deletedItems = new ArrayList<>();
+        Cidr playerCurrentIp = connection.getIpAddress();
+        for(Item item : bannedIps) {
+            Cidr firstIp = item.getIpAddress();
+            if(item.getIpAddress().equals(playerCurrentIp)
+                    || item.getKnownUuids().contains(player.getDocumentId()) && firstIp != null
+            ) {
+                if(item.getKnownUuids().size() > 1) {
+                    ipBlocks.add((playerCurrentIp == null ? firstIp : playerCurrentIp).toString() + " (multiple players)");
+                    continue;
+                }
+                item.getKnownUuids().remove(player.getDocumentId());
+                item.getKnownUsernames().remove(player.getName());
+                if(item.getIpAddress().equals(playerCurrentIp)) {
+                    bansByIp.remove(playerCurrentIp);
+                }
+                if(item.getIpAddress().equals(firstIp)) {
+                    bansByIp.remove(playerCurrentIp);
+                }
+                deletedItems.add(item);
+            } else {
+                if(item.getIpAddress().matches(playerCurrentIp)) {
+                    ipBlocks.add(item.getIpAddress().toString());
+                }
+            }
+        }
+        bannedIps.removeAll(deletedItems);
+
+        return ipBlocks;
+    }
+
+    public static class Item {
+        private final Cidr ipAddress;
+        @JsonProperty
+        private final Set<String> knownUuids = new HashSet<>();
+        @JsonProperty
+        private final Set<String> knownUsernames = new HashSet<>();
+
+        @JsonCreator
+        public Item(@JsonProperty("ip_address") Cidr ipAddress) {
+            this.ipAddress = ipAddress;
+        }
+
+        public Set<String> getKnownUuids() {
+            return knownUuids;
+        }
+
+        public Set<String> getKnownUsernames() {
+            return knownUsernames;
+        }
+
+        public Cidr getIpAddress() {
+            return ipAddress;
+        }
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
@@ -94,13 +94,13 @@ public class IpBans {
     }
 
     public Set<String> unbanAndCheckForCidrBlock(Player player) {
-        return player.isOnline() ? unbanAndCheckForCidrBlock(player, player.getConnection()) : new HashSet<>();
+        return unbanAndCheckForCidrBlock(player, player.getConnection());
     }
 
     public Set<String> unbanAndCheckForCidrBlock(Player player, Connection connection) {
         Set<String> ipBlocks = new HashSet<>();
         List<Item> deletedItems = new ArrayList<>();
-        Cidr playerCurrentIp = connection.getIpAddress();
+        Cidr playerCurrentIp = connection != null ? connection.getIpAddress() : null;
         for(Item item : bannedIps) {
             Cidr firstIp = item.getIpAddress();
             if(item.getIpAddress().equals(playerCurrentIp)
@@ -116,7 +116,7 @@ public class IpBans {
                     bansByIp.remove(playerCurrentIp);
                 }
                 if(item.getIpAddress().equals(firstIp)) {
-                    bansByIp.remove(playerCurrentIp);
+                    bansByIp.remove(firstIp);
                 }
                 deletedItems.add(item);
             } else {

--- a/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/IpBans.java
@@ -46,7 +46,8 @@ public class IpBans {
         }
     }
 
-    public Item getIpBanItem(Cidr playerIp) {
+    public Item findMatchingIpBan(Cidr playerIp) {
+        if(playerIp == null) return null;
         for(Item bannedItem : bannedIps) {
             if(playerIp.matches(bannedItem.getIpAddress())) {
                 return bannedItem;
@@ -59,12 +60,16 @@ public class IpBans {
         return bansByIp.containsKey(bannedIp);
     }
 
+    private Item addItem(Item item) {
+        bannedIps.add(item);
+        bansByIp.put(item.getIpAddress(), item);
+        return item;
+    }
+
     public void banCidr(Cidr bannedIp, Player scapegoat) {
         Item item = bansByIp.get(bannedIp);
         if(item == null) {
-            item = new Item(bannedIp);
-            bannedIps.add(item);
-            bansByIp.put(bannedIp, item);
+            item = addItem(new Item(bannedIp));
         }
         if(scapegoat != null) {
             item.getKnownUuids().add(scapegoat.getDocumentId());
@@ -84,9 +89,7 @@ public class IpBans {
         Item banByIpAddress = bansByIp.get(playerIp);
 
         if(banByIpAddress == null) {
-            banByIpAddress = new Item(playerIp);
-            bannedIps.add(banByIpAddress);
-            bansByIp.put(playerIp, banByIpAddress);
+            banByIpAddress = addItem(new Item(playerIp));
         }
 
         banByIpAddress.getKnownUuids().add(player.getDocumentId());

--- a/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
@@ -101,7 +101,6 @@ public class Connection extends SimpleChannelInboundHandler<Request> {
     public Cidr getIpAddress() {
         String whole = channel.remoteAddress().toString();
         try {
-            System.out.println(whole);
             int start = 0;
             int end = whole.length();
             for(int i = 0; i < whole.length(); i++) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
@@ -7,6 +7,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import brainwine.gameserver.util.Cidr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -95,6 +96,25 @@ public class Connection extends SimpleChannelInboundHandler<Request> {
             disconnectReason = reason;
             sendMessage(new KickMessage(reason, shouldReconnect)).addListener(ChannelFutureListener.CLOSE);
         }
+    }
+
+    public Cidr getIpAddress() {
+        String whole = channel.remoteAddress().toString();
+        int start = 0;
+        int end = whole.length();
+        for(int i = 0; i < whole.length(); i++) {
+            if(whole.charAt(i) == '/') {
+                start = i + 1;
+            }
+            if(whole.charAt(i) == ':') {
+                if(i == whole.length() - 1 || whole.charAt(i + 1) != ':') {
+                    end = i;
+                } else {
+                    i++;
+                }
+            }
+        }
+        return Cidr.create(whole.substring(start, end));
     }
     
     public void setPlayer(Player player) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/pipeline/Connection.java
@@ -100,21 +100,27 @@ public class Connection extends SimpleChannelInboundHandler<Request> {
 
     public Cidr getIpAddress() {
         String whole = channel.remoteAddress().toString();
-        int start = 0;
-        int end = whole.length();
-        for(int i = 0; i < whole.length(); i++) {
-            if(whole.charAt(i) == '/') {
-                start = i + 1;
-            }
-            if(whole.charAt(i) == ':') {
-                if(i == whole.length() - 1 || whole.charAt(i + 1) != ':') {
-                    end = i;
-                } else {
-                    i++;
+        try {
+            System.out.println(whole);
+            int start = 0;
+            int end = whole.length();
+            for(int i = 0; i < whole.length(); i++) {
+                if(whole.charAt(i) == '/') {
+                    start = i + 1;
+                }
+                if(whole.charAt(i) == ':') {
+                    if(i == whole.length() - 1 || whole.charAt(i + 1) != ':') {
+                        end = i;
+                    } else {
+                        i++;
+                    }
                 }
             }
+            return Cidr.create(whole.substring(start, end));
+        } catch(Exception e) {
+            logger.error("Error while parsing ip address for " + whole + ".", e);
+            return null;
         }
-        return Cidr.create(whole.substring(start, end));
     }
     
     public void setPlayer(Player player) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/AuthenticateRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/AuthenticateRequest.java
@@ -1,5 +1,6 @@
 package brainwine.gameserver.server.requests;
 
+import java.net.SocketAddress;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -8,11 +9,13 @@ import brainwine.gameserver.player.NotificationType;
 import brainwine.gameserver.player.Player;
 import brainwine.gameserver.player.PlayerManager;
 import brainwine.gameserver.player.PlayerRestriction;
+import brainwine.gameserver.server.IpBans;
 import brainwine.gameserver.server.OptionalField;
 import brainwine.gameserver.server.Request;
 import brainwine.gameserver.server.RequestInfo;
 import brainwine.gameserver.server.messages.NotificationMessage;
 import brainwine.gameserver.server.pipeline.Connection;
+import brainwine.gameserver.util.Cidr;
 import brainwine.gameserver.util.VersionUtils;
 import brainwine.gameserver.zone.Zone;
 
@@ -51,10 +54,41 @@ public class AuthenticateRequest extends Request {
                 connection.kick("The provided session token is invalid or has expired. Please try relogging.");
                 return;
             }
+
+            Cidr cidr = null;
+            IpBans.Item ipBan = null;
+            try {
+                cidr = connection.getIpAddress();
+                if(cidr != null) ipBan = server.getIpBans().getIpBanItem(cidr);
+            } catch(IllegalArgumentException ignored) {}
+
+            Cidr foundCidr = cidr;
+            IpBans.Item foundIpBan = ipBan;
             
             server.queueSynchronousTask(() -> {
                 Player player = playerManager.getPlayer(name);
+
                 PlayerRestriction ban = player.getCurrentBan();
+                if(ban == null && foundIpBan != null) {
+                    for(String uuid : foundIpBan.getKnownUuids()) {
+                        Player bannedPlayer = playerManager.getPlayerById(uuid);
+                        if(bannedPlayer == null) continue;
+                        PlayerRestriction otherBan = bannedPlayer.getCurrentBan();
+                        if(otherBan != null) {
+                            String newReason = otherBan.getReason() + " (You had been banned due to an IP ban)";
+                            player.ban(newReason, otherBan.getEndDate());
+                            connection.kick(newReason);
+                            return;
+                        }
+                    }
+
+                    // Try to clear the IP ban if no banned player with the ip was found.
+                    if(!server.getIpBans().unbanAndCheckForCidrBlock(player, connection).isEmpty()) {
+                        connection.kick("Your IP was banned for an unknown reason.");
+                        server.notify(String.format("%s tried to join with ip %s which is banned because of the ban on %s.", player.getName(), foundCidr, foundIpBan.getIpAddress()), NotificationType.SYSTEM);
+                        return;
+                    }
+                }
                 Zone zone = player.getZone();
                 
                 if(ban != null) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/AuthenticateRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/AuthenticateRequest.java
@@ -1,6 +1,5 @@
 package brainwine.gameserver.server.requests;
 
-import java.net.SocketAddress;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -55,15 +54,8 @@ public class AuthenticateRequest extends Request {
                 return;
             }
 
-            Cidr cidr = null;
-            IpBans.Item ipBan = null;
-            try {
-                cidr = connection.getIpAddress();
-                if(cidr != null) ipBan = server.getIpBans().getIpBanItem(cidr);
-            } catch(IllegalArgumentException ignored) {}
-
-            Cidr foundCidr = cidr;
-            IpBans.Item foundIpBan = ipBan;
+            Cidr foundCidr = connection.getIpAddress();
+            IpBans.Item foundIpBan = server.getIpBans().findMatchingIpBan(foundCidr);
             
             server.queueSynchronousTask(() -> {
                 Player player = playerManager.getPlayer(name);

--- a/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
@@ -24,9 +24,4 @@ public abstract class Cidr {
     public abstract boolean matches(Cidr other);
     public abstract boolean isSingleIpAddress();
 
-    @Override
-    public int hashCode() {
-        return toString().hashCode();
-    }
-
 }

--- a/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
@@ -6,22 +6,9 @@ public abstract class Cidr {
 
     @JsonCreator
     public static Cidr create(String string) {
-        if(string.contains(".")) {
-            try {
-                return new IpV4Cidr(string);
-            } catch(IllegalArgumentException e) {
-                return new IpV4Cidr(string);
-            }
-        } else {
-            try {
-                return new IpV4Cidr(string);
-            } catch(IllegalArgumentException e) {
-                return new IpV4Cidr(string);
-            }
-        }
+        return new IpV4Cidr(string);
     }
 
     public abstract boolean matches(Cidr other);
-    public abstract boolean isSingleIpAddress();
 
 }

--- a/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/Cidr.java
@@ -1,0 +1,32 @@
+package brainwine.gameserver.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public abstract class Cidr {
+
+    @JsonCreator
+    public static Cidr create(String string) {
+        if(string.contains(".")) {
+            try {
+                return new IpV4Cidr(string);
+            } catch(IllegalArgumentException e) {
+                return new IpV4Cidr(string);
+            }
+        } else {
+            try {
+                return new IpV4Cidr(string);
+            } catch(IllegalArgumentException e) {
+                return new IpV4Cidr(string);
+            }
+        }
+    }
+
+    public abstract boolean matches(Cidr other);
+    public abstract boolean isSingleIpAddress();
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+}

--- a/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
@@ -1,0 +1,72 @@
+package brainwine.gameserver.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class IpV4Cidr extends Cidr {
+    private final int ip;
+    private final int maskBits;
+
+    @JsonCreator
+    public IpV4Cidr(String string) throws IllegalArgumentException {
+        if(string == null || string.isEmpty()) {
+            throw new IllegalArgumentException("Null or empty.");
+        }
+
+        String[] cidrParts = string.split("/");
+        String[] ipParts = cidrParts[0].split("\\.");
+
+        if(cidrParts.length != 1 && cidrParts.length != 2) {
+            throw new IllegalArgumentException("Not 1 or 2 parts in the CIDR notation");
+        }
+
+        if(ipParts.length != 4) {
+            throw new IllegalArgumentException("Not 4 parts for the IP address");
+        }
+
+        try {
+            int a = Integer.parseInt(ipParts[0]);
+            int b = Integer.parseInt(ipParts[1]);
+            int c = Integer.parseInt(ipParts[2]);
+            int d = Integer.parseInt(ipParts[3]);
+            ip = a << 24 | b << 16 | c << 8 | d;
+            if(cidrParts.length == 2) {
+                maskBits = Integer.parseInt(cidrParts[1]);
+            } else {
+                maskBits = 32;
+            }
+        } catch(NumberFormatException e) {
+            throw new IllegalArgumentException("Malformed number component");
+        }
+    }
+
+    @Override
+    public boolean matches(Cidr obj) {
+        if(obj instanceof IpV4Cidr) {
+            IpV4Cidr other = (IpV4Cidr)obj;
+            int mask = -1 << Math.min(this.maskBits, other.maskBits);
+            return (this.ip & mask) == (other.ip & mask);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isSingleIpAddress() {
+        return maskBits == 32;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof IpV4Cidr && ((IpV4Cidr) other).ip == ip && ((IpV4Cidr)other).maskBits == maskBits;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        String result = ((ip >>> 24) & 255) + "." + ((ip >>> 16) & 255) + "." + ((ip >>> 8) & 255) + "." + (ip & 255);
+        if(maskBits != 32) {
+            result += "/" + maskBits;
+        }
+        return result;
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
@@ -3,6 +3,8 @@ package brainwine.gameserver.util;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Objects;
+
 public class IpV4Cidr extends Cidr {
     private final int ip;
     private final int maskBits;
@@ -58,6 +60,11 @@ public class IpV4Cidr extends Cidr {
     @Override
     public boolean equals(Object other) {
         return other instanceof IpV4Cidr && ((IpV4Cidr) other).ip == ip && ((IpV4Cidr)other).maskBits == maskBits;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ip, maskBits);
     }
 
     @Override

--- a/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
+++ b/gameserver/src/main/java/brainwine/gameserver/util/IpV4Cidr.java
@@ -53,11 +53,6 @@ public class IpV4Cidr extends Cidr {
     }
 
     @Override
-    public boolean isSingleIpAddress() {
-        return maskBits == 32;
-    }
-
-    @Override
     public boolean equals(Object other) {
         return other instanceof IpV4Cidr && ((IpV4Cidr) other).ip == ip && ((IpV4Cidr)other).maskBits == maskBits;
     }


### PR DESCRIPTION
So it bans the player if their ip address is banned and there is a player memorized for the ip address who has a valid ban reason. They are only kicked from the server if there is no player is remembered for the ip address or none of the known players is currently banned. This is so if the banned person creates a new account we transfer the same ban reason to the new account.

/ban command now has the syntax /ban <player> <duration> <should ban ip: true|false> <reason> which if the 3rd argument is true will also ban the player's ip address.
/unban command will try to unban the user's ip address and will print any ip addresses that might prevent them from connecting.

There are also the /banip and /unbanip commands. These can create ip bans with no known players so if there is no  ban reason to transfer the connection will just be kicked.

If you want to memorize an ip address with  a player you can do /banip <ip> <username> which will ban the connections due to the same reason as the specified players. This is not a replacement for the /ban command since it won't actually ban the specified player. If the specified player has no bans the connecting players will just be kicked.
I also implemented CIDR notation so you can specify something like 86.180.0.0/16 which will match any ip address by the first two components.
If you use the /ban command with the third argument as true it will ban the ip so that all 4 components are checked.
