### PR TITLE
Add Guild (crew) subsystem

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/GameServer.java
+++ b/gameserver/src/main/java/brainwine/gameserver/GameServer.java
@@ -25,6 +25,7 @@ import brainwine.gameserver.command.CommandExecutor;
 import brainwine.gameserver.command.CommandManager;
 import brainwine.gameserver.dailyreward.DailyRewardManager;
 import brainwine.gameserver.entity.EntityRegistry;
+import brainwine.gameserver.guild.GuildManager;
 import brainwine.gameserver.loot.LootManager;
 import brainwine.gameserver.minigame.Pandora;
 import brainwine.gameserver.player.NotificationType;
@@ -50,6 +51,7 @@ public class GameServer implements CommandExecutor {
     private final ZoneManager zoneManager;
     private final ZoneActivityManager zoneActivityManager;
     private final PlayerManager playerManager;
+    private final GuildManager guildManager;
     private final IpBans ipBans;
     private final DailyRewardManager dailyRewardManager;
     private final ProfanityManager profanityManager;
@@ -91,6 +93,7 @@ public class GameServer implements CommandExecutor {
         zoneManager.tryGenerateDefaultZone();
         zoneActivityManager = new ZoneActivityManager();
         playerManager = new PlayerManager();
+        guildManager = new GuildManager();
         ScrapMarket.getInstance().loadScrapMarketData();
         pusher = new DefaultPusher();
         NetworkRegistry.init();
@@ -122,6 +125,7 @@ public class GameServer implements CommandExecutor {
         if(lastSave + GLOBAL_SAVE_INTERVAL < System.currentTimeMillis()) {
             zoneManager.saveZones();
             playerManager.savePlayers();
+            guildManager.saveGuilds();
             ipBans.saveIpBans();
             dailyRewardManager.saveDailyRewards();
             AndroidShopPerIpHistory.getPurchaseInstance().save();
@@ -169,6 +173,8 @@ public class GameServer implements CommandExecutor {
         zoneManager.onShutdown();
         logger.info(SERVER_MARKER, "Saving player data ...");
         playerManager.savePlayers();
+        logger.info(SERVER_MARKER, "Saving guild data ...");
+        guildManager.saveGuilds();
         ipBans.saveIpBans();
         dailyRewardManager.saveDailyRewards();
         AndroidShopPerIpHistory.getPurchaseInstance().save();
@@ -202,6 +208,10 @@ public class GameServer implements CommandExecutor {
 
     public PlayerManager getPlayerManager() {
         return playerManager;
+    }
+
+    public GuildManager getGuildManager() {
+        return guildManager;
     }
 
     public Pusher getPusher() {

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildCommand.java
@@ -1,0 +1,51 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.command.Command;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+
+/**
+ * Base class for guild console commands. Ensures the executor is a player who
+ * belongs to a guild before dispatching, and provides leader/name validations.
+ */
+public abstract class GuildCommand extends Command {
+
+    public abstract void execute(Player player, Guild guild, String[] args);
+
+    @Override
+    public void execute(CommandExecutor executor, String[] args) {
+        Player player = (Player)executor;
+        Guild guild = player.getGuild();
+
+        if(guild == null) {
+            player.notify("Sorry, you are not a member of a guild.");
+            return;
+        }
+
+        execute(player, guild, args);
+    }
+
+    @Override
+    public boolean canExecute(CommandExecutor executor) {
+        return executor instanceof Player;
+    }
+
+    protected boolean requireLeader(Player player, Guild guild) {
+        if(!guild.isLeader(player.getDocumentId())) {
+            player.notify("Sorry, you are not a guild leader.");
+            return false;
+        }
+
+        return true;
+    }
+
+    protected boolean requireNamesSet(Player player, Guild guild) {
+        if(guild.getName() == null || guild.getName().isEmpty() || guild.getShortName() == null || guild.getShortName().isEmpty()) {
+            player.notify("Please set your guild's name and shortname first.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildHelpCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildHelpCommand.java
@@ -1,0 +1,22 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.dialog.DialogHelper;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+
+@CommandInfo(name = "ghelp", description = "Show the guild command help screen.")
+public class GuildHelpCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        String dialog = guild.isLeader(player.getDocumentId()) ? "guild_owner_help" : "guild_member_help";
+        player.showDialog(DialogHelper.getDialog(dialog));
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/ghelp";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildInfoCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildInfoCommand.java
@@ -1,0 +1,64 @@
+package brainwine.gameserver.command.guild;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.dialog.Dialog;
+import brainwine.gameserver.dialog.DialogSection;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+import brainwine.gameserver.zone.Zone;
+import brainwine.gameserver.zone.ZoneManager;
+
+@CommandInfo(name = "ginfo", description = "Display information about your guild.")
+public class GuildInfoCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        PlayerManager playerManager = GameServer.getInstance().getPlayerManager();
+        ZoneManager zoneManager = GameServer.getInstance().getZoneManager();
+
+        Player leader = playerManager.getPlayerById(guild.getLeaderId());
+        String leaderName = leader == null ? " " : leader.getName();
+
+        Zone home = guild.getZoneId() == null ? null : zoneManager.getZone(guild.getZoneId());
+        String zoneName = home == null ? "None" : home.getName();
+
+        String guildName = "Unnamed";
+
+        if(guild.getName() != null && guild.getShortName() != null) {
+            guildName = String.format("%s [%s]", guild.getName(), guild.getShortName());
+        }
+
+        // List members other than the leader, alphabetically
+        List<String> memberNames = guild.getMembers().stream()
+                .map(playerManager::getPlayerById)
+                .filter(Objects::nonNull)
+                .map(Player::getName)
+                .filter(name -> !name.equals(leaderName))
+                .sorted()
+                .collect(Collectors.toList());
+
+        String members = memberNames.isEmpty() ? "none yet!" : String.join(", ", memberNames);
+
+        Dialog dialog = new Dialog()
+                .addSection(new DialogSection().setTitle(guildName))
+                .addSection(new DialogSection().setTextColor("4d5b82").setText("Leader: " + leaderName))
+                .addSection(new DialogSection().setTextColor("4d5b82").setText("Home World: " + zoneName))
+                .addSection(new DialogSection().setText(" "))
+                .addSection(new DialogSection().setTextColor("4d5b82").setText("Members"))
+                .addSection(new DialogSection().setText(members));
+
+        player.showDialog(dialog);
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/ginfo";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildInviteCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildInviteCommand.java
@@ -1,0 +1,39 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+
+@CommandInfo(name = "ginvite", description = "Invite a player to your guild.")
+public class GuildInviteCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        if(!requireLeader(player, guild) || !requireNamesSet(player, guild) || !checkArgumentCount(player, args, 1)) {
+            return;
+        }
+
+        String name = String.join(" ", args).trim();
+        PlayerManager playerManager = GameServer.getInstance().getPlayerManager();
+        Player invitee = playerManager.getPlayer(name);
+
+        if(invitee == null) {
+            player.notify(String.format("Player %s not found.", name));
+        } else if(invitee.getGuildId() != null) {
+            player.notify(String.format("Sorry, %s already belongs to a guild.", invitee.getName()));
+        } else if(invitee.isOnline() && guild.nearObelisk(player) && guild.nearObelisk(invitee)) {
+            guild.offerMembership(invitee);
+            player.notify(String.format("%s has been invited to the \"%s\" guild.", invitee.getName(), guild.getName()));
+        } else {
+            player.notify(String.format("Please meet %s at the guild obelisk to invite them.", invitee.getName()));
+        }
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/ginvite <player>";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildLeaderCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildLeaderCommand.java
@@ -1,0 +1,61 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.dialog.Dialog;
+import brainwine.gameserver.dialog.DialogSection;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+
+@CommandInfo(name = "gleader", description = "Pass guild leadership to another member.")
+public class GuildLeaderCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        if(!requireLeader(player, guild) || !requireNamesSet(player, guild) || !checkArgumentCount(player, args, 1)) {
+            return;
+        }
+
+        String name = String.join(" ", args).trim();
+        PlayerManager playerManager = GameServer.getInstance().getPlayerManager();
+        Player invitee = playerManager.getPlayer(name);
+
+        if(invitee == null) {
+            player.notify(String.format("Player %s not found.", name));
+            return;
+        }
+
+        if(invitee.getGuildId() != null && !guild.getId().equals(invitee.getGuildId())) {
+            player.notify(String.format("Sorry, %s already belongs to a guild.", invitee.getName()));
+            return;
+        }
+
+        if(!invitee.isOnline() || !guild.nearObelisk(player) || !guild.nearObelisk(invitee)) {
+            player.notify(String.format("Please meet %s at the guild obelisk to pass leadership.", invitee.getName()));
+            return;
+        }
+
+        // Confirm with the current leader before offering leadership
+        Dialog confirm = new Dialog()
+                .setActions("yesno")
+                .addSection(new DialogSection()
+                        .setTitle("Pass Leadership")
+                        .setText(String.format("This will revoke your %s guild leadership and make you a guild member. Are you sure?", guild.getName())));
+
+        player.showDialog(confirm, data -> {
+            if(data.length == 1 && "cancel".equals(data[0])) {
+                return;
+            }
+
+            guild.offerLeadership(invitee);
+            player.notify(String.format("%s has been invited to LEAD the \"%s\" guild.", invitee.getName(), guild.getName()));
+        });
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/gleader <player>";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildQuitCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildQuitCommand.java
@@ -1,0 +1,39 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.dialog.Dialog;
+import brainwine.gameserver.dialog.DialogSection;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+
+@CommandInfo(name = "gquit", description = "Leave your guild.")
+public class GuildQuitCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        if(guild.isLeader(player.getDocumentId())) {
+            player.notify("You'll need to designate a new guild leader before quitting.");
+            return;
+        }
+
+        Dialog confirm = new Dialog()
+                .setActions("yesno")
+                .addSection(new DialogSection()
+                        .setTitle("Leave Guild")
+                        .setText(String.format("This will remove you from the %s guild. Are you sure?", guild.getName())));
+
+        player.showDialog(confirm, data -> {
+            if(data.length == 1 && "cancel".equals(data[0])) {
+                return;
+            }
+
+            guild.removeMember(player, false);
+        });
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/gquit";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildRemoveCommand.java
+++ b/gameserver/src/main/java/brainwine/gameserver/command/guild/GuildRemoveCommand.java
@@ -1,0 +1,42 @@
+package brainwine.gameserver.command.guild;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.command.CommandExecutor;
+import brainwine.gameserver.command.CommandInfo;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+
+@CommandInfo(name = "gremove", description = "Remove a player from your guild.")
+public class GuildRemoveCommand extends GuildCommand {
+
+    @Override
+    public void execute(Player player, Guild guild, String[] args) {
+        if(!requireLeader(player, guild) || !checkArgumentCount(player, args, 1)) {
+            return;
+        }
+
+        String name = String.join(" ", args).trim();
+
+        if(name.equalsIgnoreCase(player.getName())) {
+            player.notify("You cannot remove yourself, try a /gquit command.");
+            return;
+        }
+
+        PlayerManager playerManager = GameServer.getInstance().getPlayerManager();
+        Player target = playerManager.getPlayer(name);
+
+        if(target == null) {
+            player.notify(String.format("Player %s not found.", name));
+        } else if(!guild.getId().equals(target.getGuildId())) {
+            player.notify(String.format("Sorry, %s does not belong to your guild.", target.getName()));
+        } else {
+            guild.removeMember(target, true);
+        }
+    }
+
+    @Override
+    public String getUsage(CommandExecutor executor) {
+        return "/gremove <player>";
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/guild/Guild.java
+++ b/gameserver/src/main/java/brainwine/gameserver/guild/Guild.java
@@ -5,9 +5,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import brainwine.gameserver.GameServer;
@@ -27,7 +26,6 @@ import brainwine.gameserver.zone.Zone;
  *
  * <p>Ported from the canonical {@code models/guild.rb}.
  */
-@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Guild {
 
@@ -95,6 +93,7 @@ public class Guild {
     /**
      * @return {@code true} if every visual field has been configured.
      */
+    @JsonIgnore
     public boolean isComplete() {
         return isPresent(name) && isPresent(shortName) && isPresent(color1) && isPresent(color2)
                 && isPresent(color3) && isPresent(color4) && isPresent(signColor) && isPresent(sign);
@@ -260,6 +259,30 @@ public class Guild {
 
     public Set<String> getMembers() {
         return members;
+    }
+
+    public String getColor1() {
+        return color1;
+    }
+
+    public String getColor2() {
+        return color2;
+    }
+
+    public String getColor3() {
+        return color3;
+    }
+
+    public String getColor4() {
+        return color4;
+    }
+
+    public String getSign() {
+        return sign;
+    }
+
+    public String getSignColor() {
+        return signColor;
     }
 
     private void persist(Player player) {

--- a/gameserver/src/main/java/brainwine/gameserver/guild/Guild.java
+++ b/gameserver/src/main/java/brainwine/gameserver/guild/Guild.java
@@ -1,0 +1,315 @@
+package brainwine.gameserver.guild;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.dialog.Dialog;
+import brainwine.gameserver.dialog.DialogSection;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.player.PlayerManager;
+import brainwine.gameserver.util.MathUtils;
+import brainwine.gameserver.zone.MetaBlock;
+import brainwine.gameserver.zone.Zone;
+
+/**
+ * A player guild (a.k.a. crew). Created by placing a Guild Obelisk
+ * ({@code signs/guild}, code 915) and configured through its dialog. The
+ * obelisk's metadata mirrors the guild's visual settings; members display the
+ * guild's short name as a colored badge next to their name.
+ *
+ * <p>Ported from the canonical {@code models/guild.rb}.
+ */
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Guild {
+
+    public static final int OBELISK_RANGE = 10;
+
+    private String id;
+    private String name;
+    private String shortName;
+    private String zoneId;
+    private int x = -1;
+    private int y = -1;
+    private String leaderId;
+    private Set<String> members = new LinkedHashSet<>();
+    private String color1;
+    private String color2;
+    private String color3;
+    private String color4;
+    private String sign;
+    private String signColor;
+
+    @JsonCreator
+    protected Guild() {}
+
+    public Guild(String id, String leaderId, String zoneId, int x, int y) {
+        this.id = id;
+        this.leaderId = leaderId;
+        this.zoneId = zoneId;
+        this.x = x;
+        this.y = y;
+        this.members.add(leaderId);
+    }
+
+    /**
+     * Applies obelisk dialog metadata (gn/gsn/c1-c4/s/sc) to the guild's fields.
+     */
+    public void applyMetadata(Map<String, Object> metadata) {
+        if(metadata.containsKey("gn")) name = asString(metadata.get("gn"));
+        if(metadata.containsKey("gsn")) shortName = asString(metadata.get("gsn"));
+        if(metadata.containsKey("c1")) color1 = asString(metadata.get("c1"));
+        if(metadata.containsKey("c2")) color2 = asString(metadata.get("c2"));
+        if(metadata.containsKey("c3")) color3 = asString(metadata.get("c3"));
+        if(metadata.containsKey("c4")) color4 = asString(metadata.get("c4"));
+        if(metadata.containsKey("s")) sign = asString(metadata.get("s"));
+        if(metadata.containsKey("sc")) signColor = asString(metadata.get("sc"));
+    }
+
+    /**
+     * Builds the obelisk metadata map (gn/gsn/c1-c4/s/sc + guild id) from the
+     * guild's fields, omitting any unset values.
+     */
+    public Map<String, Object> constructMetadata() {
+        Map<String, Object> meta = new HashMap<>();
+        putIfPresent(meta, "gn", name);
+        putIfPresent(meta, "gsn", shortName);
+        putIfPresent(meta, "c1", color1);
+        putIfPresent(meta, "c2", color2);
+        putIfPresent(meta, "c3", color3);
+        putIfPresent(meta, "c4", color4);
+        putIfPresent(meta, "s", sign);
+        putIfPresent(meta, "sc", signColor);
+        meta.put("g", id);
+        return meta;
+    }
+
+    /**
+     * @return {@code true} if every visual field has been configured.
+     */
+    public boolean isComplete() {
+        return isPresent(name) && isPresent(shortName) && isPresent(color1) && isPresent(color2)
+                && isPresent(color3) && isPresent(color4) && isPresent(signColor) && isPresent(sign);
+    }
+
+    public boolean isMember(String playerId) {
+        return members.contains(playerId);
+    }
+
+    public boolean isLeader(String playerId) {
+        return leaderId != null && leaderId.equals(playerId);
+    }
+
+    /**
+     * Invites a player to join this guild via a yes/no dialog. They become a
+     * member if they accept.
+     */
+    public void offerMembership(Player player) {
+        Dialog dialog = new Dialog()
+                .setActions("yesno")
+                .addSection(new DialogSection()
+                        .setTitle("Guild Membership")
+                        .setText(String.format("You have been invited to join the \"%s\" guild. Would you like to join?", name)));
+
+        player.showDialog(dialog, data -> {
+            if(data.length == 1 && "cancel".equals(data[0])) {
+                return;
+            }
+
+            if(player.getGuildId() != null) {
+                player.notify("You already belong to a guild.");
+                return;
+            }
+
+            addMember(player);
+        });
+    }
+
+    /**
+     * Offers guild leadership to a player via a yes/no dialog. They become the
+     * leader if they accept.
+     */
+    public void offerLeadership(Player player) {
+        Dialog dialog = new Dialog()
+                .setActions("yesno")
+                .addSection(new DialogSection()
+                        .setTitle("Guild Leadership")
+                        .setText(String.format("You have been invited to LEAD the \"%s\" guild. Do you accept?", name)));
+
+        player.showDialog(dialog, data -> {
+            if(data.length == 1 && "cancel".equals(data[0])) {
+                return;
+            }
+
+            setLeader(player);
+        });
+    }
+
+    public void addMember(Player player) {
+        members.add(player.getDocumentId());
+        player.setGuildId(id);
+        persist(player);
+        alert(leaderId, String.format("%s is now a member of the \"%s\" guild.", player.getName(), name));
+        player.notify(String.format("You are now a member of the \"%s\" guild.", name));
+        player.broadcastGuildAffiliation();
+    }
+
+    public void removeMember(Player player, boolean alertLeader) {
+        members.remove(player.getDocumentId());
+        player.setGuildId(null);
+        persist(player);
+        player.notify(String.format("You are no longer a member of the \"%s\" guild.", name));
+
+        if(alertLeader) {
+            alert(leaderId, String.format("%s has been removed from the \"%s\" guild.", player.getName(), name));
+        }
+
+        player.broadcastGuildAffiliation();
+    }
+
+    /**
+     * Transfers leadership to the given player (who becomes a member if they
+     * weren't already), keeping the previous leader as a regular member.
+     */
+    public void setLeader(Player player) {
+        String previousLeaderId = leaderId;
+        leaderId = player.getDocumentId();
+        members.add(player.getDocumentId());
+        persist(player);
+        updateObeliskOwner(player);
+
+        if(previousLeaderId != null) {
+            alert(previousLeaderId, String.format("%s is now the leader of the \"%s\" guild.", player.getName(), name));
+        }
+
+        player.notify(String.format("You are now the leader of the \"%s\" guild.", name));
+    }
+
+    public void setLocation(String zoneId, int x, int y) {
+        this.zoneId = zoneId;
+        this.x = x;
+        this.y = y;
+    }
+
+    public void clearLocation() {
+        this.zoneId = null;
+        this.x = -1;
+        this.y = -1;
+    }
+
+    /**
+     * @return {@code true} if the player is in the guild's home zone and within
+     * {@link #OBELISK_RANGE} of its obelisk.
+     */
+    public boolean nearObelisk(Player player) {
+        return zoneId != null && player.getZone() != null && zoneId.equals(player.getZone().getDocumentId())
+                && MathUtils.inRange(x, y, player.getX(), player.getY(), OBELISK_RANGE);
+    }
+
+    /**
+     * Broadcasts the short-name badge of every online member to their zones, so
+     * clients can render the colored guild tag next to member names.
+     */
+    public void broadcastClientChanges() {
+        PlayerManager playerManager = GameServer.getInstance().getPlayerManager();
+
+        for(String memberId : members) {
+            Player member = playerManager.getPlayerById(memberId);
+
+            if(member != null && member.isOnline()) {
+                member.broadcastGuildAffiliation();
+            }
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getZoneId() {
+        return zoneId;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public String getLeaderId() {
+        return leaderId;
+    }
+
+    public Set<String> getMembers() {
+        return members;
+    }
+
+    private void persist(Player player) {
+        GameServer.getInstance().getGuildManager().saveGuild(this);
+        GameServer.getInstance().getPlayerManager().savePlayer(player);
+    }
+
+    /**
+     * Transfers ownership of the obelisk block to the new leader so only they
+     * can reconfigure the guild.
+     */
+    private void updateObeliskOwner(Player newLeader) {
+        if(zoneId == null) {
+            return;
+        }
+
+        Zone zone = GameServer.getInstance().getZoneManager().getZone(zoneId);
+
+        if(zone != null) {
+            MetaBlock metaBlock = zone.getMetaBlock(x, y);
+
+            if(metaBlock != null) {
+                metaBlock.setOwner(newLeader);
+            }
+        }
+    }
+
+    private void alert(String playerId, String message) {
+        if(playerId == null) {
+            return;
+        }
+
+        Player player = GameServer.getInstance().getPlayerManager().getPlayerById(playerId);
+
+        if(player != null && player.isOnline()) {
+            player.notify(message);
+        }
+    }
+
+    private static String asString(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    private static void putIfPresent(Map<String, Object> map, String key, String value) {
+        if(isPresent(value)) {
+            map.put(key, value);
+        }
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/guild/GuildManager.java
+++ b/gameserver/src/main/java/brainwine/gameserver/guild/GuildManager.java
@@ -1,0 +1,143 @@
+package brainwine.gameserver.guild;
+
+import static brainwine.shared.LogMarkers.SERVER_MARKER;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import brainwine.gameserver.player.Player;
+import brainwine.shared.JsonHelper;
+
+/**
+ * In-memory registry and disk store for {@link Guild}s. Guilds are persisted as
+ * {@code guilds/<id>.json}, mirroring {@link brainwine.gameserver.player.PlayerManager}.
+ */
+public class GuildManager {
+
+    private static final Logger logger = LogManager.getLogger();
+    private final Map<String, Guild> guildsById = new HashMap<>();
+
+    public GuildManager() {
+        loadGuilds();
+    }
+
+    private void loadGuilds() {
+        logger.info(SERVER_MARKER, "Loading guild data ...");
+        File dataDir = new File("guilds");
+        dataDir.mkdirs();
+
+        for(File file : dataDir.listFiles()) {
+            if(!file.isDirectory()) {
+                loadGuild(file);
+            }
+        }
+
+        logger.info(SERVER_MARKER, "Successfully loaded {} guild(s)", guildsById.size());
+    }
+
+    private void loadGuild(File file) {
+        String id = file.getName().replace(".json", "");
+
+        try {
+            Guild guild = JsonHelper.readValue(file, Guild.class);
+            guildsById.put(guild.getId() == null ? id : guild.getId(), guild);
+        } catch(Exception e) {
+            logger.error(SERVER_MARKER, "Could not load configuration for guild id {}", id, e);
+        }
+    }
+
+    public void saveGuilds() {
+        for(Guild guild : guildsById.values()) {
+            saveGuild(guild);
+        }
+    }
+
+    public void saveGuild(Guild guild) {
+        File file = new File("guilds", guild.getId() + ".json");
+
+        try {
+            JsonHelper.writeValue(file, guild);
+        } catch(Exception e) {
+            logger.error(SERVER_MARKER, "Could not save guild id {}", guild.getId(), e);
+        }
+    }
+
+    /**
+     * Creates a new guild led by the given player, registers and persists it,
+     * and links the player to it.
+     */
+    public Guild createGuild(Player leader, String zoneId, int x, int y) {
+        String id = UUID.randomUUID().toString();
+        Guild guild = new Guild(id, leader.getDocumentId(), zoneId, x, y);
+        guildsById.put(id, guild);
+        leader.setGuildId(id);
+        saveGuild(guild);
+        return guild;
+    }
+
+    /**
+     * Validates a candidate name/short-name for the given guild: length bounds
+     * and uniqueness across all other guilds. Returns an empty list if valid.
+     */
+    public List<String> validateNames(Guild guild, String name, String shortName) {
+        List<String> errors = new ArrayList<>();
+
+        if(name == null || name.length() < 3 || name.length() > 20) {
+            errors.add("Guild name must be between 3 and 20 characters.");
+        } else {
+            Guild other = getGuildByName(name);
+
+            if(other != null && !other.getId().equals(guild.getId())) {
+                errors.add(String.format("Guild name '%s' is already taken.", name));
+            }
+        }
+
+        if(shortName == null || shortName.length() < 2 || shortName.length() > 8) {
+            errors.add("Short name must be between 2 and 8 characters.");
+        } else {
+            Guild other = getGuildByShortName(shortName);
+
+            if(other != null && !other.getId().equals(guild.getId())) {
+                errors.add(String.format("Short name '%s' is already taken.", shortName));
+            }
+        }
+
+        return errors;
+    }
+
+    public Guild getGuild(String id) {
+        return id == null ? null : guildsById.get(id);
+    }
+
+    public Guild getGuildByName(String name) {
+        for(Guild guild : guildsById.values()) {
+            if(name.equalsIgnoreCase(guild.getName())) {
+                return guild;
+            }
+        }
+
+        return null;
+    }
+
+    public Guild getGuildByShortName(String shortName) {
+        for(Guild guild : guildsById.values()) {
+            if(shortName.equalsIgnoreCase(guild.getShortName())) {
+                return guild;
+            }
+        }
+
+        return null;
+    }
+
+    public Collection<Guild> getGuilds() {
+        return guildsById.values();
+    }
+}

--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/DialogInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/DialogInteraction.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 import brainwine.gameserver.GameServer;
 import brainwine.gameserver.chat.PlayerProfanity;
+import brainwine.gameserver.dialog.DialogHelper;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.guild.GuildManager;
 import brainwine.gameserver.entity.Entity;
 import brainwine.gameserver.item.Item;
 import brainwine.gameserver.item.Layer;
@@ -133,8 +136,48 @@ public class DialogInteraction implements ItemInteraction {
             metadata.put("cd", true);
         }
         
+        // Guild obelisks sync their dialog config to the player's guild
+        if(item.hasId("signs/guild")) {
+            applyGuildConfiguration(zone, player, x, y, item, metaBlock, metadata);
+            return;
+        }
+
         // Update meta block
         zone.setMetaBlock(x, y, item, player, metadata);
+    }
+
+    /**
+     * Applies a guild obelisk's dialog config to the player's guild, validating the
+     * name and short name for length and uniqueness. On success the guild is saved
+     * and members' badges are re-broadcast; on failure the obelisk reverts to its
+     * previous metadata.
+     */
+    private void applyGuildConfiguration(Zone zone, Player player, int x, int y, Item item, MetaBlock metaBlock,
+            Map<String, Object> metadata) {
+        GuildManager guildManager = GameServer.getInstance().getGuildManager();
+        Guild guild = player.getGuild();
+
+        // If the player somehow has no guild, just store the metadata generically
+        if(guild == null) {
+            zone.setMetaBlock(x, y, item, player, metadata);
+            return;
+        }
+
+        // Validate the candidate name/short name before mutating the guild
+        String name = metadata.containsKey("gn") ? String.valueOf(metadata.get("gn")) : guild.getName();
+        String shortName = metadata.containsKey("gsn") ? String.valueOf(metadata.get("gsn")) : guild.getShortName();
+        List<String> errors = guildManager.validateNames(guild, name, shortName);
+
+        if(errors.isEmpty()) {
+            guild.applyMetadata(metadata);
+            guildManager.saveGuild(guild);
+            zone.setMetaBlock(x, y, item, player, metadata);
+            guild.broadcastClientChanges();
+        } else {
+            player.showDialog(DialogHelper.messageDialog("Guild", String.join("\n", errors)));
+            Map<String, Object> previousData = metaBlock == null ? new HashMap<>() : new HashMap<>(metaBlock.getMetadata());
+            zone.setMetaBlock(x, y, item, player, previousData);
+        }
     }
 
     public boolean shouldFilterValue(Item item, String sectionKey) {

--- a/gameserver/src/main/java/brainwine/gameserver/player/Player.java
+++ b/gameserver/src/main/java/brainwine/gameserver/player/Player.java
@@ -43,6 +43,7 @@ import brainwine.gameserver.entity.Entity;
 import brainwine.gameserver.entity.EntityAttack;
 import brainwine.gameserver.entity.EntityStatus;
 import brainwine.gameserver.entity.npc.Npc;
+import brainwine.gameserver.guild.Guild;
 import brainwine.gameserver.item.Action;
 import brainwine.gameserver.item.DamageType;
 import brainwine.gameserver.item.Item;
@@ -136,6 +137,7 @@ public class Player extends Entity implements CommandExecutor {
     private List<String> bookmarkedZones;
     private Set<String> followees;
     private Set<String> followers;
+    private String guildId;
     private Set<String> lootCodes;
     private Set<Achievement> achievements;
     private Map<String, Integer> orders = new HashMap<>();
@@ -218,6 +220,7 @@ public class Player extends Entity implements CommandExecutor {
         this.bookmarkedZones = config.getBookmarkedZones();
         this.followees = config.getFollowees();
         this.followers = config.getFollowers();
+        this.guildId = config.getGuildId();
         this.lootCodes = config.getLootCodes();
         this.achievements = config.getAchievements();
         this.orders = config.getOrders();
@@ -655,6 +658,19 @@ public class Player extends Entity implements CommandExecutor {
         sendMessage(new FollowMessage(followees.stream().map(playerManager::getPlayerById).filter(Objects::nonNull).collect(Collectors.toList()), 0));
         sendMessage(new FollowMessage(followers.stream().map(playerManager::getPlayerById).filter(Objects::nonNull).collect(Collectors.toList()), 1));
         sendMessage(new EventMessage("socialInfoReady", null));
+
+        // Send guild affiliation badges: broadcast ours to the zone, receive peers'
+        broadcastGuildAffiliation();
+
+        for(Player peer : zone.getPlayers()) {
+            if(peer != this) {
+                String peerShortName = peer.getGuildShortName();
+
+                if(peerShortName != null) {
+                    sendMessage(new EntityChangeMessage(peer.getId(), Collections.<String, Object>singletonMap("gn", peerShortName)));
+                }
+            }
+        }
         
         // Clear invalid bookmarks
         bookmarkedZones.removeIf(bookmark -> zoneManager.getZone(bookmark) == null || !zoneManager.getZone(bookmark).canJoin(this));
@@ -1316,6 +1332,39 @@ public class Player extends Entity implements CommandExecutor {
 
     public Set<String> getFollowees() {
         return Collections.unmodifiableSet(followees);
+    }
+
+    public String getGuildId() {
+        return guildId;
+    }
+
+    public void setGuildId(String guildId) {
+        this.guildId = guildId;
+    }
+
+    public Guild getGuild() {
+        return GameServer.getInstance().getGuildManager().getGuild(guildId);
+    }
+
+    /**
+     * @return The short name of this player's guild, or {@code null} if they aren't in one.
+     */
+    public String getGuildShortName() {
+        Guild guild = getGuild();
+        return guild == null ? null : guild.getShortName();
+    }
+
+    /**
+     * Broadcasts this player's guild short-name badge to everyone in their zone.
+     * An empty value clears the badge (e.g. after leaving a guild).
+     */
+    public void broadcastGuildAffiliation() {
+        if(zone == null) {
+            return;
+        }
+
+        String shortName = getGuildShortName();
+        zone.sendMessage(new EntityChangeMessage(id, Collections.<String, Object>singletonMap("gn", shortName == null ? "" : shortName)));
     }
 
     private void addFollower(Player player) {

--- a/gameserver/src/main/java/brainwine/gameserver/player/PlayerConfigFile.java
+++ b/gameserver/src/main/java/brainwine/gameserver/player/PlayerConfigFile.java
@@ -49,6 +49,7 @@ public class PlayerConfigFile {
     private List<String> bookmarkedZones = new ArrayList<>();
     private Set<String> followees = new HashSet<>();
     private Set<String> followers = new HashSet<>();
+    private String guildId;
     private Set<String> lootCodes = new HashSet<>();
     private Set<Achievement> achievements = new HashSet<>();
     private Map<String, Integer> orders = new HashMap<>();
@@ -86,6 +87,7 @@ public class PlayerConfigFile {
         this.bookmarkedZones = player.getBookmarkedZones();
         this.followees = player.getFollowees();
         this.followers = player.getFollowers();
+        this.guildId = player.getGuildId();
         this.lootCodes = player.getLootCodes();
         this.achievements = player.getAchievements();
         this.orders = player.getOrders();
@@ -247,6 +249,10 @@ public class PlayerConfigFile {
     @JsonSetter(nulls = Nulls.SKIP, contentNulls = Nulls.SKIP)
     public Set<String> getFollowees() {
         return followees;
+    }
+
+    public String getGuildId() {
+        return guildId;
     }
     
     @JsonSetter(nulls = Nulls.SKIP, contentNulls = Nulls.SKIP)

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
@@ -3,8 +3,10 @@ package brainwine.gameserver.server.requests;
 import java.util.Deque;
 import java.util.Map;
 
+import brainwine.gameserver.GameServer;
 import brainwine.gameserver.command.CommandAccessLevel;
 import brainwine.gameserver.entity.Entity;
+import brainwine.gameserver.guild.Guild;
 import brainwine.gameserver.item.Action;
 import brainwine.gameserver.item.Fieldability;
 import brainwine.gameserver.item.Item;
@@ -184,6 +186,16 @@ public class BlockMineRequest extends PlayerRequest {
             if(item.hasUse(ItemUseType.GUARD)) {
                 String dungeonId = MapHelper.getString(metadata, "@");
                 zone.destroyGuardBlock(dungeonId, player);
+            }
+        }
+
+        // Clear the guild's home location if its obelisk is being mined
+        if(item.hasId("signs/guild")) {
+            Guild guild = player.getGuild();
+
+            if(guild != null) {
+                guild.clearLocation();
+                GameServer.getInstance().getGuildManager().saveGuild(guild);
             }
         }
         

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockPlaceRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockPlaceRequest.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import brainwine.gameserver.GameServer;
 import brainwine.gameserver.entity.EntityConfig;
 import brainwine.gameserver.entity.npc.Npc;
+import brainwine.gameserver.guild.Guild;
+import brainwine.gameserver.guild.GuildManager;
 import brainwine.gameserver.item.DamageType;
 import brainwine.gameserver.item.Item;
 import brainwine.gameserver.item.ItemGroup;
@@ -135,7 +137,18 @@ public class BlockPlaceRequest extends PlayerRequest {
             fail(player, "You can't place blocks in the tutorial world");
             return;
         }
-        
+
+        // A guild obelisk founds a new guild, so you can't place one if you're already in a guild
+        if(item.hasId("signs/guild") && player.getGuild() != null) {
+            Guild guild = player.getGuild();
+            String name = guild.getName();
+            String message = guild.isLeader(player.getDocumentId())
+                    ? (name == null ? "You already own a guild." : String.format("You already own the '%s' guild.", name))
+                    : (name == null ? "You are already a member of a guild." : String.format("You are already a member of the '%s' guild.", name));
+            fail(player, message);
+            return;
+        }
+
         if(layer == Layer.LIQUID) {
             mod = 5;
         } else if(item.getMod() == ModType.ROTATION && !item.isMirrorable()) {
@@ -477,11 +490,25 @@ public class BlockPlaceRequest extends PlayerRequest {
                     metaBlock.setProperty("$", "?");
                 }
                 break;
+            case "signs/guild":
+                processGuildObeliskPlacement(zone, player);
+                break;
             // No valid item; do nothing
             default: break;
         }
     }
-    
+
+    /**
+     * Creates a new guild led by the placer and mirrors its (initially empty)
+     * settings onto the obelisk's metadata, owned by the leader.
+     */
+    private void processGuildObeliskPlacement(Zone zone, Player player) {
+        GuildManager guildManager = GameServer.getInstance().getGuildManager();
+        Guild guild = guildManager.createGuild(player, zone.getDocumentId(), x, y);
+        zone.setMetaBlock(x, y, item, player, guild.constructMetadata());
+        player.notify("You've founded a guild! Use the obelisk to set its name, colors and crest.");
+    }
+
     private void fail(Player player, String reason) {
         player.notify(reason);
         Block block = player.getZone().getBlock(x, y);

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/GiveRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/GiveRequest.java
@@ -1,0 +1,57 @@
+package brainwine.gameserver.server.requests;
+
+import static brainwine.gameserver.player.NotificationType.SYSTEM;
+
+import brainwine.gameserver.GameServer;
+import brainwine.gameserver.item.Item;
+import brainwine.gameserver.item.ItemRegistry;
+import brainwine.gameserver.player.Player;
+import brainwine.gameserver.server.PlayerRequest;
+import brainwine.gameserver.server.RequestInfo;
+
+/**
+ * Handles the v3 client's "/give &lt;player|me&gt; &lt;item&gt; [quantity]" console command.
+ *
+ * The client intercepts /give with its own GiveConsoleCommand and sends a dedicated Give request
+ * (id 200) carrying [playerName, itemCode, quantity] — it does NOT route through the chat/console
+ * command pipeline. brainwine only implemented /give as a console command (id 47), so the client's
+ * request hit no handler and was silently dropped. This wires it up. Admin-only, mirroring
+ * {@code GiveCommand}.
+ */
+@RequestInfo(id = 200)
+public class GiveRequest extends PlayerRequest {
+
+    public String playerName;
+    public int itemCode;
+    public int quantity;
+
+    @Override
+    public void process(Player player) {
+        // Never trust the client: gate on admin server-side (the console command is admin-only too).
+        if(!player.isAdmin()) {
+            return;
+        }
+
+        Player target = GameServer.getInstance().getPlayerManager().getPlayer(playerName);
+
+        if(target == null) {
+            player.notify("That player does not exist.", SYSTEM);
+            return;
+        }
+
+        Item item = ItemRegistry.getItem(itemCode);
+
+        if(item.isAir()) {
+            player.notify("This item does not exist.", SYSTEM);
+            return;
+        }
+
+        int amount = quantity > 0 ? quantity : 1;
+        target.getInventory().addItem(item, amount, true);
+        target.notify(String.format("You received %s %s from an administrator.", amount, item.getTitle()), SYSTEM);
+
+        if(target != player) {
+            player.notify(String.format("Gave %s %s to %s", amount, item.getTitle(), target.getName()), SYSTEM);
+        }
+    }
+}


### PR DESCRIPTION
Adds the player **Guild / crew** subsystem. The old Deepworld config + client already support guilds (the client renders the `gn` short-name badge), but brainwine never implemented the server side — this fills that gap. Ported from my `deepworld-server` work.

## What it does
- Place a **Guild Obelisk** (`signs/guild`) to found a guild; configure its name / short-name / 4 colors / crest via the obelisk dialog.
- Membership & leadership console commands: `/ghelp /ginfo /ginvite /gremove /gleader /gquit` (invite/leadership use yes/no dialogs).
- Members display a colored guild short-name badge next to their name (broadcast as `gn` via `EntityChangeMessage`, synced on zone entry).

## Changes
- **New:** `guild/{Guild,GuildManager}` (guilds persisted as `guilds/<id>.json`), `command/guild/*` (base + 7 commands), and `server/requests/GiveRequest` (request id 200 — the v3 client's `/give`, which only had the console `GiveCommand` before).
- **Hooks into existing classes:** `GameServer` (construct/register `GuildManager` + save on tick & shutdown), `Player` (`guildId` + `getGuild`/`getGuildShortName`/`broadcastGuildAffiliation` + badge sync on zone entry), `PlayerConfigFile` (persist `guildId`), `DialogInteraction` (obelisk configure + name/short-name validation), `BlockPlaceRequest` (found a guild on placement + "already in a guild" guard), `BlockMineRequest` (clear the guild's home location when its obelisk is mined).
- `signs/guild` already exists in `deepworld-config`, so no config change is needed.

Compiles and builds the dist jar (JDK 8 / gradle-wrapper 7.5.1). The guild code is additive — your APIs matched almost 1:1.

## Heads up (NOT caused by this PR)
A clean `git clone --recurse-submodules` + `gradlew dist` + boot currently fails *before any guild code runs*, on config↔code mismatches with the **pinned `deepworld-config` (`34e1ec6`)**:
1. `automata` / `science` were removed from the `Skill` enum (your `remove automata skill` / `remove science skill` commits) but the pinned config still defines + uses them (`config-skills.yml` + items' `crafting/placing skill: ['automata'|'science', N]`).
2. `GroupDungeon`'s static default config references an item that isn't in the pinned `config-items.yml` → `BlockState` throws `Item air not found`.

The pinned submodule looks stale vs your current config (the `config-skills.yml` you shared is a different format — `max_level:` + `skills:` wrapper). **Bumping the `deepworld-config` pin to your current config should clear the boot.**

Also non-fatal: `config-achievements` references `TradingAchievement` + `AgeAchievement`, which aren't implemented here (logged as a skip-warning). I have both in my fork if you'd like them added.
